### PR TITLE
Remove the config option to modify Prometheus' advertised port

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,6 @@ Run:
 
 Now browse to http://<prometheus-juju-app-address>:9090/
 
-The above assumes you're using the default value for `advertised-port`. If
-you customized this value from 9090 to some other value, change the command
-above accordingly.
-
 The default prometheus.yml includes a configuration that scrapes metrics
 from Prometheus itself. Execute the following query to show TSDB stats:
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,4 @@
 options:
-    advertised-port:
-        description: The port where the Prometheus should listen for requests.
-        type: int
-        default: 9090
     external-labels:
         description: |
           A JSON string of key-value pairs that specify the labels to

--- a/src/domain.py
+++ b/src/domain.py
@@ -100,7 +100,12 @@ def build_juju_pod_spec(app_name,
                         image_meta):
 
     external_labels = json.loads(charm_config['external-labels'])
-    advertised_port = charm_config['advertised-port']
+
+    # There is never ever a need to customize the advertised port of a
+    # containerized Prometheus instance so we are removing that config
+    # option and making it statically default to its typical 9090
+    advertised_port = 9090
+
     monitor_k8s = charm_config['monitor-k8s']
     prom_config = build_prometheus_config(external_labels=external_labels,
                                           advertised_port=advertised_port,
@@ -137,12 +142,14 @@ def build_prometheus_config(external_labels, advertised_port, monitor_k8s):
             'external_labels': external_labels
         }
     )
+
+    # Scrape its own metrics
     prometheus_config.add_scrape_config({
         'job_name': 'prometheus',
         'scrape_interval': '5s',
         'static_configs': [{
             'targets': [
-                f'localhost:{advertised_port}'
+                'localhost:{}'.format(advertised_port)
             ]
         }]
     })

--- a/src/interface_http.py
+++ b/src/interface_http.py
@@ -32,8 +32,7 @@ class PrometheusInterface(Object):
     def render_relation_data(self):
         logging.debug('render-relation-data in')
         for relation in self.model.relations[self.relation_name]:
-            relation.data[self.model.unit]['prometheus-port'] = \
-                str(self.framework.model.config['advertised-port'])
+            relation.data[self.model.unit]['prometheus-port'] = '9090'
         logging.debug('render-relation-data out')
 
     def on_relation_joined(self, event):

--- a/test/domain_test.py
+++ b/test/domain_test.py
@@ -27,7 +27,6 @@ class BuildJujuPodSpecTest(unittest.TestCase):
         # Set up
         mock_app_name = f'{uuid4()}'
 
-        mock_advertised_port = random.randint(1, 65535)
         mock_external_labels = {
             f"{uuid4()}": f"{uuid4()}",
             f"{uuid4()}": f"{uuid4()}",
@@ -35,7 +34,6 @@ class BuildJujuPodSpecTest(unittest.TestCase):
         }
 
         mock_config = {
-            'advertised-port': mock_advertised_port,
             'external-labels': json.dumps(mock_external_labels),
             'monitor-k8s': False
         }
@@ -62,13 +60,13 @@ class BuildJujuPodSpecTest(unittest.TestCase):
                 'password': mock_image_meta.repo_password
             },
             'ports': [{
-                'containerPort': mock_config['advertised-port'],
+                'containerPort': 9090,
                 'protocol': 'TCP'
             }],
             'readinessProbe': {
                 'httpGet': {
                     'path': '/-/ready',
-                    'port': mock_config['advertised-port']
+                    'port': 9090
                 },
                 'initialDelaySeconds': 10,
                 'timeoutSeconds': 30
@@ -76,7 +74,7 @@ class BuildJujuPodSpecTest(unittest.TestCase):
             'livenessProbe': {
                 'httpGet': {
                     'path': '/-/healthy',
-                    'port': mock_config['advertised-port']
+                    'port': 9090
                 },
                 'initialDelaySeconds': 30,
                 'timeoutSeconds': 30
@@ -97,7 +95,7 @@ class BuildJujuPodSpecTest(unittest.TestCase):
                                 'static_configs': [
                                     {
                                         'targets': [
-                                            f'localhost:{mock_advertised_port}'
+                                            'localhost:9090'
                                         ]
                                     }
                                 ]


### PR DESCRIPTION
In a containerized world, there is no need to customize Prometheus'
advertised port since there's virtually zero chance of it conflicting
with another process. If a different port must be exposed to the
outside world, that can be done via the Service resource or some
other mechanism.