### PR TITLE
Add interface for retrieving alerting config from charmed AlertManager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 .tox
+.orig
 *.egg-info
 **/__pycache__
 .coverage

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -13,6 +13,9 @@ series:
 provides:
     http-api:
         interface: prometheus-http-api
+requires:
+    alertmanager:
+        interface: prometheus-alerting-config
 resources:
     prometheus-image:
         type: oci-image

--- a/src/adapters/framework.py
+++ b/src/adapters/framework.py
@@ -68,7 +68,7 @@ class FrameworkAdapter:
     def __init__(self, framework):
         self._framework = framework
 
-    def am_i_leader(self):
+    def unit_is_leader(self):
         return self._framework.model.unit.is_leader()
 
     def get_app_name(self):
@@ -86,8 +86,14 @@ class FrameworkAdapter:
     def get_model_name(self):
         return self._framework.model.name
 
+    def get_relations(self, relation_name):
+        return self._framework.model.relations[relation_name]
+
     def get_resources_repo(self):
         return self._framework.model.resources
+
+    def get_unit(self):
+        return self._framework.model.unit
 
     def get_unit_name(self):
         return self._framework.model.unit.name

--- a/src/domain.py
+++ b/src/domain.py
@@ -1,12 +1,14 @@
 import copy
 import json
-import yaml
 import logging
+import yaml
 
 logger = logging.getLogger()
 
 import sys
 sys.path.append('lib')
+
+logger = logging.getLogger()
 
 from ops.model import (
     ActiveStatus,
@@ -87,10 +89,11 @@ class PrometheusConfigFile:
     https://prometheus.io/docs/prometheus/latest/configuration/configuration
     '''
 
-    def __init__(self, global_opts):
+    def __init__(self, global_opts, alerting={}):
         self._config_dict = {
             'global': global_opts,
             'scrape_configs': [],
+            'alerting': alerting
         }
 
     def add_scrape_config(self, scrape_config):
@@ -101,6 +104,9 @@ class PrometheusConfigFile:
 
     def yaml_dump(self):
         return yaml.dump(self._config_dict)
+
+    def __repr__(self):
+        return str(self._config_dict)
 
 
 # DOMAIN SERVICES
@@ -189,7 +195,8 @@ def build_prometheus_cli_args(charm_config):
 
 def build_juju_pod_spec(app_name,
                         charm_config,
-                        image_meta):
+                        image_meta,
+                        alerting_config={}):
 
     # There is never ever a need to customize the advertised port of a
     # containerized Prometheus instance so we are removing that config
@@ -340,4 +347,5 @@ def build_prometheus_config(charm_config):
         for scrape_config in k8s_scrape_configs:
             prometheus_config.add_scrape_config(scrape_config)
 
+    logger.debug("Build prom config: {}".format(prometheus_config))
     return prometheus_config

--- a/src/interface_alertmanager.py
+++ b/src/interface_alertmanager.py
@@ -1,0 +1,55 @@
+import json
+import logging
+
+logger = logging.getLogger()
+
+from ops.framework import (
+    EventSource,
+    Object,
+    ObjectEvents,
+)
+from ops.framework import EventBase
+from adapters.framework import FrameworkAdapter
+
+
+class NewAlertManagerRelationEvent(EventBase):
+
+    def __init__(self, handle, remote_data):
+        super().__init__(handle)
+        self.data = dict(remote_data)
+
+    # The Operator Framework will serialize and deserialize this event object
+    # as it passes it to the charm. The following snapshot and restore methos
+    # ensure that our underlying data don't get lost along the way.
+
+    def snapshot(self):
+        return json.dumps(self.data)
+
+    def restore(self, snapshot):
+        self.data = json.loads(snapshot)
+
+
+class AlertManagerEvents(ObjectEvents):
+    new_relation = EventSource(NewAlertManagerRelationEvent)
+
+
+class AlertManagerInterface(Object):
+    on = AlertManagerEvents()
+
+    def __init__(self, charm, relation_name):
+        super().__init__(charm, relation_name)
+
+        self.fw_adapter = FrameworkAdapter(self.framework)
+        self.relation_name = relation_name
+
+        self.fw_adapter.observe(charm.on[relation_name].relation_changed,
+                                self.on_relation_changed)
+
+    def on_relation_changed(self, event):
+        remote_data = event.relation.data[event.unit]
+        logging.debug(
+            "Received remote_data: {}".format(dict(remote_data))
+        )
+
+        logger.debug("Emitting new_relation event")
+        self.on.new_relation.emit(remote_data)

--- a/test/charm_test.py
+++ b/test/charm_test.py
@@ -1,62 +1,28 @@
-from pathlib import Path
-import shutil
+import json
 import sys
-import tempfile
 import unittest
 from unittest.mock import (
     call,
     create_autospec,
     patch
 )
-# from uuid import uuid4
+from uuid import uuid4
 
 sys.path.append('lib')
-from ops.charm import (
-    CharmMeta,
-)
 from ops.framework import (
     EventBase,
-    Framework
 )
 from ops.model import (
-    # ActiveStatus,
+    ActiveStatus,
     MaintenanceStatus,
 )
-
 sys.path.append('src')
 from adapters import (
     framework,
 )
-# from ops.testing import Harness
 import charm
 import domain
 
-
-class CharmTest(unittest.TestCase):
-
-    def setUp(self):
-        self.tmpdir = Path(tempfile.mkdtemp())
-        # Ensure that we clean up the tmp directory even when the test
-        # fails or errors out for whatever reason.
-        self.addCleanup(shutil.rmtree, self.tmpdir)
-
-    def create_framework(self):
-        raw_meta = {
-            'provides': {'http-api': {"interface": "prometheus-http-api"}}
-        }
-        framework = Framework(self.tmpdir / "framework.data",
-                              self.tmpdir, CharmMeta(raw=raw_meta), None)
-        # Ensure that the Framework object is closed and cleaned up even
-        # when the test fails or errors out.
-        self.addCleanup(framework.close)
-
-        return framework
-
-    @patch('charm.FrameworkAdapter', spec_set=True, autospec=True)
-    def test__init__works_without_a_hitch(self,
-                                          mock_framework_adapter_cls):
-        # Exercise
-        charm.Charm(self.create_framework(), None)
 
 # This test is disabled due to the:
 # https://github.com/canonical/operator/issues/307
@@ -110,6 +76,95 @@ class CharmTest(unittest.TestCase):
 #         # ]
 
 
+class OnConfigChangedHandlerTest(unittest.TestCase):
+
+    # We are mocking the time module here so that we don't actually wait
+    # 1 second per loop during test exectution.
+    @patch('charm.build_juju_unit_status', spec_set=True, autospec=True)
+    @patch('charm.k8s', spec_set=True, autospec=True)
+    @patch('charm.time', spec_set=True, autospec=True)
+    @patch('charm.build_juju_pod_spec', spec_set=True, autospec=True)
+    @patch('charm.set_juju_pod_spec', spec_set=True, autospec=True)
+    @patch('charm.StoredState', spec_set=True, autospec=True)
+    def test__it_blocks_until_pod_is_ready(
+            self,
+            mock_stored_state_cls,
+            mock_pod_spec,
+            mock_juju_pod_spec,
+            mock_time,
+            mock_k8s_mod,
+            mock_build_juju_unit_status_func):
+        # Setup
+        mock_fw_adapter_cls = \
+            create_autospec(framework.FrameworkAdapter, spec_set=True)
+        mock_fw_adapter = mock_fw_adapter_cls.return_value
+
+        mock_juju_unit_states = [
+            MaintenanceStatus(str(uuid4())),
+            MaintenanceStatus(str(uuid4())),
+            ActiveStatus(str(uuid4())),
+        ]
+        mock_build_juju_unit_status_func.side_effect = mock_juju_unit_states
+
+        mock_event_cls = create_autospec(EventBase, spec_set=True)
+        mock_event = mock_event_cls.return_value
+
+        mock_state = mock_stored_state_cls.return_value
+
+        # Exercise
+        charm.on_config_changed_handler(mock_event,
+                                        mock_fw_adapter,
+                                        mock_state)
+
+        # Assert
+        assert mock_fw_adapter.set_unit_status.call_count == \
+            len(mock_juju_unit_states)
+        assert mock_fw_adapter.set_unit_status.call_args_list == [
+            call(status) for status in mock_juju_unit_states
+        ]
+
+
+class OnNewAlertManagerRelationHandler(unittest.TestCase):
+
+    @patch('charm.build_juju_pod_spec', spec_set=True, autospec=True)
+    def test__it_updates_the_juju_pod_spec_with_alerting_config(
+            self,
+            mock_build_juju_pod_spec_func):
+        # Setup
+        mock_fw_adapter_cls = \
+            create_autospec(framework.FrameworkAdapter,
+                            spec_set=True)
+        mock_fw = mock_fw_adapter_cls.return_value
+        mock_fw.unit_is_leader.return_value = True
+
+        mock_event_cls = create_autospec(EventBase)
+        mock_event = mock_event_cls.return_value
+        mock_data = {str(uuid4()): str(uuid4())}
+        mock_event.data = dict(alerting_config=json.dumps(mock_data))
+
+        mock_prom_juju_pod_spec = create_autospec(domain.PrometheusJujuPodSpec)
+        mock_build_juju_pod_spec_func.return_value = mock_prom_juju_pod_spec
+
+        # Exercise
+        charm.on_new_alertmanager_relation_handler(mock_event, mock_fw)
+
+        # Assert
+        assert mock_build_juju_pod_spec_func.call_count == 1
+        assert mock_build_juju_pod_spec_func.call_args == \
+            call(app_name=mock_fw.get_app_name.return_value,
+                 charm_config=mock_fw.get_config.return_value,
+                 image_meta=mock_fw.get_image_meta.return_value,
+                 alerting_config=mock_data)
+
+        assert mock_fw.set_pod_spec.call_count == 1
+        assert mock_fw.set_pod_spec.call_args == \
+            call(mock_prom_juju_pod_spec.to_dict())
+
+        assert mock_fw.set_unit_status.call_count == 1
+        args, kwargs = mock_fw.set_unit_status.call_args_list[0]
+        assert type(args[0]) == MaintenanceStatus
+
+
 class OnStartHandlerTest(unittest.TestCase):
 
     @patch('charm.build_juju_pod_spec', spec_set=True, autospec=True)
@@ -120,7 +175,7 @@ class OnStartHandlerTest(unittest.TestCase):
             create_autospec(framework.FrameworkAdapter,
                             spec_set=True)
         mock_fw = mock_fw_adapter_cls.return_value
-        mock_fw.am_i_leader.return_value = True
+        mock_fw.unit_is_leader.return_value = True
 
         mock_event_cls = create_autospec(EventBase, spec_set=True)
         mock_event = mock_event_cls.return_value
@@ -136,7 +191,8 @@ class OnStartHandlerTest(unittest.TestCase):
         assert mock_build_juju_pod_spec_func.call_args == \
             call(app_name=mock_fw.get_app_name.return_value,
                  charm_config=mock_fw.get_config.return_value,
-                 image_meta=mock_fw.get_image_meta.return_value)
+                 image_meta=mock_fw.get_image_meta.return_value,
+                 alerting_config={})
 
         assert mock_fw.set_pod_spec.call_count == 1
         assert mock_fw.set_pod_spec.call_args == \

--- a/test/domain_test.py
+++ b/test/domain_test.py
@@ -158,7 +158,8 @@ class BuildJujuPodSpecTest(unittest.TestCase):
                                     }
                                 ]
                             }
-                        ]
+                        ],
+                        'alerting': {}
                     })
                 }
             }]
@@ -316,7 +317,8 @@ class BuildPrometheusConfig(unittest.TestCase):
                         }
                     ]
                 }
-            ]
+            ],
+            'alerting': {}
         }
 
         self.assertEqual(
@@ -349,7 +351,8 @@ class BuildPrometheusConfig(unittest.TestCase):
                         }
                     ]
                 }
-            ]
+            ],
+            'alerting': {}
         }
 
         with open('templates/prometheus-k8s.yml') as prom_yaml:

--- a/test/interface_alertmanager_test.py
+++ b/test/interface_alertmanager_test.py
@@ -1,0 +1,78 @@
+import json
+import sys
+from unittest.mock import (
+    call,
+    MagicMock,
+    patch,
+)
+import unittest
+from uuid import uuid4
+
+sys.path.append('lib')
+sys.path.append('src')
+from interface_alertmanager import (
+    AlertManagerInterface,
+    NewAlertManagerRelationEvent,
+)
+
+
+class NewAlertManagerRelationEventTest(unittest.TestCase):
+
+    @patch('interface_alertmanager.EventBase', spec_set=True)
+    def test__it_snapshots_the_remote_data(self, mock_event_base_cls):
+        # Setup
+        mock_handle = MagicMock()
+        mock_data = {
+            str(uuid4()): str(uuid4()),
+            str(uuid4()): str(uuid4()),
+            str(uuid4()): str(uuid4()),
+        }
+
+        # Exercise
+        new_relation_event = NewAlertManagerRelationEvent(mock_handle,
+                                                          mock_data)
+        snapshot = new_relation_event.snapshot()
+
+        # Assert
+        assert snapshot == json.dumps(mock_data)
+
+    @patch('interface_alertmanager.EventBase', spec_set=True)
+    def test__it_restores_the_data(self, mock_event_base_cls):
+        # Setup
+        mock_handle = MagicMock()
+        mock_data = {
+            str(uuid4()): str(uuid4()),
+            str(uuid4()): str(uuid4()),
+            str(uuid4()): str(uuid4()),
+        }
+
+        # Exercise
+        snapshot = json.dumps(mock_data)
+        new_relation_event = NewAlertManagerRelationEvent(mock_handle, {})
+        new_relation_event.restore(snapshot)
+
+        # Assert
+        assert new_relation_event.data == mock_data
+
+
+class AlertManagerInterfaceTest(unittest.TestCase):
+
+    @patch('interface_alertmanager.FrameworkAdapter', spec_set=True)
+    def test__it_observes_the_relation_changed_event(
+            self,
+            mock_fw_adapter_cls):
+        # Setup
+        mock_fw_adapter = mock_fw_adapter_cls.return_value
+        mock_charm = MagicMock()
+
+        mock_relation_name = str(uuid4())
+
+        # Exercise
+        alertmanager_interface = \
+            AlertManagerInterface(mock_charm, mock_relation_name)
+
+        # Assert
+        assert mock_fw_adapter.observe.call_count == 1
+        assert mock_fw_adapter.observe.call_args == \
+            call(mock_charm.on[mock_relation_name].relation_changed,
+                 alertmanager_interface.on_relation_changed)


### PR DESCRIPTION
This commit allows the charm to retrieve a configuration string from the
alertmanager charm. The configuration string is a JSON string that this
charm converts to a dict that is then inserted to another dict that
ultimately gets serialized into a YAML-formatted prometheus config file.

While this charm is agnostic to the contents of the JSON string, in
AlertManager's current iteration, it uses the `kube_sd_configs` method
so that Prometheus can quickly detect changes in the number of
AlertManager pods without waiting for any Juju events.