### PR TITLE
First approach to the TLS termination implementation for the Prometheus

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "mod/operator"]
 	path = mod/operator
 	url = https://github.com/canonical/operator
+[submodule "mod/jinja"]
+	path = mod/jinja
+	url = https://github.com/pallets/jinja

--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ Quick Start
 
 ```
 git submodule update --init --recursive
-sudo snap install juju --classic
 sudo snap install microk8s --classic
+sudo snap install juju --classic
 sudo microk8s.enable dns dashboard registry storage metrics-server ingress
 sudo usermod -a -G microk8s $(whoami)
+sudo chown -f -R $USER ~/.kube
 ```
 
 Log out then log back in so that the new group membership is applied to
@@ -35,7 +36,8 @@ Optional: Grab coffee/beer/tea or do a 5k run. Once the above is done, do:
 ```
 juju create-storage-pool operator-storage kubernetes storage-class=microk8s-hostpath
 juju add-model lma
-juju deploy . --resource prometheus-image=prom/prometheus:v2.18.1
+juju deploy . --resource prometheus-image=prom/prometheus:v2.18.1 --resource nginx-image=nginx:1.19.0
+
 ```
 
 Wait until `juju status` shows that the prometheus app has a status of active.
@@ -77,7 +79,7 @@ Monitoring Kubernetes
 To monitor the kubernetes cluster, deploy it with the following config option:
 
     juju deploy . --resource prometheus-image=prom/prometheus:v2.18.1 \
-        --config monitor-k8s=true
+        --resource nginx-image=nginx:1.19.0 --config monitor-k8s=true
 
 If the charm has already been deployed, you may also configure it at runtime:
 
@@ -232,7 +234,7 @@ For example, given that you have already deployed an application named
 `config-changed` handler, execute the following:
 
 
-    kubectl exec -it pod/prometheus-operator-0 -n lma -- /bin/sh
+    kubectl exec -it pod/prometheus-operator-0 -n lma -- /bin/bash
 
 
 This will open an interactive shell within the operator pod. Then, install

--- a/config.yaml
+++ b/config.yaml
@@ -1,114 +1,131 @@
 options:
-    log-level:
-        description: |
-          Prometheus server log level (only log messages with the given severity
-          or above). Must be one of: [debug, info, warn, error, fatal].
-          If not set, the Prometheus default one (info) will be used.
-        type: string
-        default:
-    web-max-connections:
-        description: |
-          Maximum number of simultaneous connections.
-        type: int
-        default: 512
-    web-read-timeout:
-        description: |
-          Maximum duration before timing out read of the request, and
-          closing idle connections.
-        type: string
-        default: 5m
-    web-external-url:
-        description: |
-          The URL under which Prometheus is externally reachable (for example,
-          if Prometheus is served via a reverse proxy).
-          Used for generating relative and absolute links back to
-          Prometheus itself. If the URL has a path portion, it will be used to
-          prefix all HTTP endpoints served by Prometheus.
+  enforce-pod-restart:
+    type: boolean
+    default: false
+    description: |
+      If set to True, charm will forcibly shutdown and re-create the workload
+      pod(s), one by one. If there is only one pod - any config modification
+      will lead to the short service downtime.
+  ssl_cert:
+    type: string
+    default:
+    description: |
+      SSL certificate to install and use for Prometheus endpoint.
+  ssl_key:
+    type: string
+    default:
+    description: |
+      SSL key to use with certificate specified as ssl_cert.
+  log-level:
+    description: |
+      Prometheus server log level (only log messages with the given severity
+      or above). Must be one of: [debug, info, warn, error, fatal].
+      If not set, the Prometheus default one (info) will be used.
+    type: string
+    default:
+  web-max-connections:
+    description: |
+      Maximum number of simultaneous connections.
+    type: int
+    default: 512
+  web-read-timeout:
+    description: |
+      Maximum duration before timing out read of the request, and
+      closing idle connections.
+    type: string
+    default: 5m
+  web-external-url:
+    description: |
+      The URL under which Prometheus is externally reachable (for example,
+      if Prometheus is served via a reverse proxy).
+      Used for generating relative and absolute links back to
+      Prometheus itself. If the URL has a path portion, it will be used to
+      prefix all HTTP endpoints served by Prometheus.
 
-          If omitted, relevant URL components will be derived automatically.
-        type: string
-        default: ""
-    # TODO: After the nginx reverse proxy sidecar will be implemented,
-    # it will be a good idea to restrict this kind of access to some particular
-    # IP address range at least.
-    web-enable-admin-api:
-        description: |
-          Enable API endpoints for admin control actions.
+      If omitted, relevant URL components will be derived automatically.
+    type: string
+    default: ""
+  # TODO: After the nginx reverse proxy sidecar will be implemented,
+  # it will be a good idea to restrict this kind of access to some particular
+  # IP address range at least.
+  web-enable-admin-api:
+    description: |
+      Enable API endpoints for admin control actions.
 
-          As of Prometheus 2.0, this flag controls access to the
-          administrative HTTP API which includes functionality such as
-          deleting time series. This is disabled by default.
+      As of Prometheus 2.0, this flag controls access to the
+      administrative HTTP API which includes functionality such as
+      deleting time series. This is disabled by default.
 
-          If enabled, administrative and mutating functionality will
-          be accessible under the /api/*/admin/ paths.
-        type: boolean
-        default: false
-    web-page-title:
-        description: |
-          Document title of Prometheus instance.
-        type: string
-        default: "Charmed LMA - Prometheus TSDB, Collection & Processing"
-    tsdb-retention-time:
-        description: |
-          How long to retain samples in the storage.
-          Units Supported: y, w, d, h, m, s, ms.
-        type: string
-        default: 15d
-    tsdb-wal-compression:
-        description: |
-          This flag enables compression of the write-ahead log (WAL).
-          Depending on your data, you can expect the WAL size to be
-          halved with little extra cpu load.
-        type: boolean
-        default: false
-    alertmanager-notification-queue-capacity:
-        description: |
-          The capacity of the queue for pending alert manager notifications.
-        type: int
-        default: 10000
-    alertmanager-timeout:
-        description: |
-          Timeout for sending alerts to AlertManager.
-        type: string
-        default: 10s
-    external-labels:
-        description: |
-          A JSON string of key-value pairs that specify the labels to
-          attach to metrics in this Prometheus instance when they get pulled
-          by an aggregating parent. This is useful in the case of federation
-          where, for example, you want each datacenter to have its own
-          Prometheus instance and then have a global instance that pulls from
-          each of these datacenter instances. By specifying a unique set of
-          external_labels for each datacenter instance, you can easily determine
-          in the aggregating Prometheus instance which datacenter a metric is
-          coming from. Note that you are not limited to one instance per
-          datacenter. The datacenter example here is arbitrary and you are free
-          to organize your federation's hierarchy as you see fit.
-          Ex. '{ "cluster": "datacenter1" }'. Both keys and values may be
-          arbitrarily chosen as you see fit.
-        type: string
-        default: "{}"
-    monitor-k8s:
-        description: |
-          Adds additional scrape configs to the prometheus config file such that
-          it collects metrics about the k8s cluster it is deployed in. It's
-          important that metrics-server be running in the kube-system namespace
-          otherwise the charm will remain in the blocked status.
-        type: boolean
-        default: false
-    scrape-interval:
-        description: |
-          How frequently to scrape targets by default.
-        type: string
-        default: 1m
-    scrape-timeout:
-        description: |
-          How long until a scrape request times out.
-        type: string
-        default: 10s
-    evaluation-interval:
-        description: |
-          How frequently rules will be evaluated.
-        type: string
-        default: 1m
+      If enabled, administrative and mutating functionality will
+      be accessible under the /api/*/admin/ paths.
+    type: boolean
+    default: false
+  web-page-title:
+    description: |
+      Document title of Prometheus instance.
+    type: string
+    default: "Charmed LMA - Prometheus TSDB, Collection & Processing"
+  tsdb-retention-time:
+    description: |
+      How long to retain samples in the storage.
+      Units Supported: y, w, d, h, m, s, ms.
+    type: string
+    default: 15d
+  tsdb-wal-compression:
+    description: |
+      This flag enables compression of the write-ahead log (WAL).
+      Depending on your data, you can expect the WAL size to be
+      halved with little extra cpu load.
+    type: boolean
+    default: false
+  alertmanager-notification-queue-capacity:
+    description: |
+      The capacity of the queue for pending alert manager notifications.
+    type: int
+    default: 10000
+  alertmanager-timeout:
+    description: |
+      Timeout for sending alerts to AlertManager.
+    type: string
+    default: 10s
+  external-labels:
+    description: |
+      A JSON string of key-value pairs that specify the labels to
+      attach to metrics in this Prometheus instance when they get pulled
+      by an aggregating parent. This is useful in the case of federation
+      where, for example, you want each datacenter to have its own
+      Prometheus instance and then have a global instance that pulls from
+      each of these datacenter instances. By specifying a unique set of
+      external_labels for each datacenter instance, you can easily determine
+      in the aggregating Prometheus instance which datacenter a metric is
+      coming from. Note that you are not limited to one instance per
+      datacenter. The datacenter example here is arbitrary and you are free
+      to organize your federation's hierarchy as you see fit.
+      Ex. '{ "cluster": "datacenter1" }'. Both keys and values may be
+      arbitrarily chosen as you see fit.
+    type: string
+    default: "{}"
+  monitor-k8s:
+    description: |
+      Adds additional scrape configs to the prometheus config file such that
+      it collects metrics about the k8s cluster it is deployed in. It's
+      important that metrics-server be running in the kube-system namespace
+      otherwise the charm will remain in the blocked status.
+    type: boolean
+    default: false
+  scrape-interval:
+    description: |
+      How frequently to scrape targets by default.
+    type: string
+    default: 1m
+  scrape-timeout:
+    description: |
+      How long until a scrape request times out.
+    type: string
+    default: 10s
+  evaluation-interval:
+    description: |
+      How frequently rules will be evaluated.
+    type: string
+    default: 1m
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -20,6 +20,9 @@ resources:
     prometheus-image:
         type: oci-image
         description: "Image used for UI pod."
+    nginx-image:
+        type: oci-image
+        description: "NGINX image used for TLS termination, if required"
 storage:
   database:
     type: filesystem

--- a/templates/prometheus-nginx.conf.j2
+++ b/templates/prometheus-nginx.conf.j2
@@ -1,0 +1,26 @@
+server {
+    listen 80;
+    server_name _;
+    access_log /var/log/nginx/prometheus-http.access.log main;
+    error_log /var/log/nginx/prometheus-http.error.log;
+    {%- if ssl_cert %}
+    return 301 https://$host$request_uri;
+    {%- else %}
+    location / {
+        proxy_pass http://localhost:{{ advertised_port }};
+    }
+    {%- endif %}
+}
+{%- if ssl_cert %}
+server {
+    server_name  _;
+    listen 443 ssl;
+    access_log  /var/log/nginx/prometheus-https.access.log main;
+    error_log /var/log/nginx/prometheus-https.error.log;
+    ssl_certificate /etc/nginx/ssl/prom-tls.pem;
+    ssl_certificate_key /etc/nginx/ssl/prom-tls.key;
+    location / {
+        proxy_pass http://localhost:{{ advertised_port }};
+    }
+}
+{%- endif %}

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,3 +3,4 @@ pytest
 pytest-cov
 pytest-randomly
 flake8
+jinja2


### PR DESCRIPTION
Implementing the TLS termination for the Prometheus using nginx as a sidecar container acting as a reverse
proxy, hiding non-secure Prometheus endpoint behind itself.

Also, the 'enforce-pod-restart' config option has been introduced, giving the user an option to forcibly restart the workloads after the config-changed event (since current Juju/charm architecture does not give an option to either send system signal or execute any service control command).